### PR TITLE
[SDL2 TTF] Fix package name in find_package

### DIFF
--- a/ports/sdl2-ttf/CMakeLists.txt
+++ b/ports/sdl2-ttf/CMakeLists.txt
@@ -3,7 +3,7 @@ project(SDL2_TTF C)
 
 find_path(SDL_INCLUDE_DIR SDL2/SDL.h)
 find_library(SDL_LIBRARY NAMES SDL2d SDL2)
-find_package(FreeType REQUIRED)
+find_package(Freetype REQUIRED)
 
 add_library(SDL2_ttf SDL_ttf.c version.rc)
 


### PR DESCRIPTION
The package name is called "Freetype", not "FreeType". This doesn't pose a problem on Windows, but Linux and OS X are case-sensitive.

We caught this problem when we copied over the SDL_TTF's cmakeLists.txt to our SDL_TTF fork and it failed to build, see here:
https://travis-ci.org/SuperTux/supertux/jobs/447488501#L2759